### PR TITLE
feat: Add unit tests for authentication

### DIFF
--- a/features/auth/AuthContext.test.tsx
+++ b/features/auth/AuthContext.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-native';
+import { AuthProvider, useAuth } from './AuthContext';
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  sendPasswordResetEmail,
+  User,
+} from 'firebase/auth';
+
+// Mock firebase.config first
+jest.mock('@/firebase.config', () => ({
+  auth: {
+    // Mock any properties of auth if they are accessed directly
+  },
+}));
+
+// Mock Firebase Auth module
+jest.mock('firebase/auth', () => ({
+  // Keep getAuth if it's used, otherwise it can be removed
+  getAuth: jest.fn(),
+  // The actual onAuthStateChanged function is what we need to mock
+  onAuthStateChanged: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  createUserWithEmailAndPassword: jest.fn(),
+  signOut: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+}));
+
+describe('AuthContext', () => {
+  // Typecast mocks for easier use
+  const mockedOnAuthStateChanged = onAuthStateChanged as jest.Mock;
+  const mockedSignInWithEmailAndPassword = signInWithEmailAndPassword as jest.Mock;
+  const mockedCreateUserWithEmailAndPassword = createUserWithEmailAndPassword as jest.Mock;
+  const mockedSignOut = signOut as jest.Mock;
+  const mockedSendPasswordResetEmail = sendPasswordResetEmail as jest.Mock;
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should initialize, set user to null when not logged in', () => {
+    // Setup onAuthStateChanged to immediately call back with null
+    mockedOnAuthStateChanged.mockImplementation((auth, callback) => {
+      callback(null);
+      return jest.fn(); // Return a mock unsubscribe function
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    expect(result.current.initializing).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('should initialize and set user when logged in', () => {
+    const mockUser = { uid: 'test-uid', email: 'test@example.com' } as User;
+    // Setup onAuthStateChanged to immediately call back with a mock user
+    mockedOnAuthStateChanged.mockImplementation((auth, callback) => {
+      callback(mockUser);
+      return jest.fn();
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    expect(result.current.initializing).toBe(false);
+    expect(result.current.user).toBe(mockUser);
+  });
+
+  it('should call signInWithEmailAndPassword on login', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const email = 'test@example.com';
+    const password = 'password123';
+
+    await act(async () => {
+      await result.current.login(email, password);
+    });
+
+    expect(mockedSignInWithEmailAndPassword).toHaveBeenCalledWith(expect.any(Object), email, password);
+  });
+
+  it('should call createUserWithEmailAndPassword on signup', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const email = 'test@example.com';
+    const password = 'password123';
+
+    await act(async () => {
+      await result.current.signup(email, password);
+    });
+
+    expect(mockedCreateUserWithEmailAndPassword).toHaveBeenCalledWith(expect.any(Object), email, password);
+  });
+
+  it('should call signOut on logout', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(mockedSignOut).toHaveBeenCalled();
+  });
+
+  it('should call sendPasswordResetEmail on resetPassword', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const email = 'test@example.com';
+
+    await act(async () => {
+      await result.current.resetPassword(email);
+    });
+
+    expect(mockedSendPasswordResetEmail).toHaveBeenCalledWith(expect.any(Object), email);
+  });
+});

--- a/features/auth/validation.test.ts
+++ b/features/auth/validation.test.ts
@@ -1,0 +1,49 @@
+import { isValidEmail, validatePasswordStrength } from './validation';
+
+describe('Auth Validation', () => {
+  describe('isValidEmail', () => {
+    it('should return true for valid emails', () => {
+      expect(isValidEmail('test@example.com')).toBe(true);
+      expect(isValidEmail('test.name@example.co.uk')).toBe(true);
+    });
+
+    it('should return false for invalid emails', () => {
+      expect(isValidEmail('test')).toBe(false);
+      expect(isValidEmail('test@example')).toBe(false);
+      expect(isValidEmail('test@.com')).toBe(false);
+      expect(isValidEmail('@example.com')).toBe(false);
+    });
+
+    it('should trim whitespace', () => {
+      expect(isValidEmail('  test@example.com  ')).toBe(true);
+    });
+  });
+
+  describe('validatePasswordStrength', () => {
+    it('should return ok for valid passwords', () => {
+      expect(validatePasswordStrength('password123')).toEqual({ ok: true });
+      expect(validatePasswordStrength('anotherValidPass1')).toEqual({ ok: true });
+    });
+
+    it('should return error for passwords less than 8 characters', () => {
+      expect(validatePasswordStrength('pass')).toEqual({
+        ok: false,
+        reason: 'Password must be at least 8 characters.',
+      });
+    });
+
+    it('should return error for passwords without numbers', () => {
+      expect(validatePasswordStrength('password')).toEqual({
+        ok: false,
+        reason: 'Use letters and numbers.',
+      });
+    });
+
+    it('should return error for passwords without letters', () => {
+      expect(validatePasswordStrength('12345678')).toEqual({
+        ok: false,
+        reason: 'Use letters and numbers.',
+      });
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'jest-expo',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
 };


### PR DESCRIPTION
This commit introduces unit tests for the authentication-related functionality in the application.

- Adds unit tests for the validation functions `isValidEmail` and `validatePasswordStrength` in `features/auth/validation.test.ts`. The tests cover valid inputs, invalid inputs, and edge cases.

- Adds unit tests for the `AuthContext` in `features/auth/AuthContext.test.tsx`. These tests mock the Firebase authentication module to test the `login`, `signup`, `logout`, and `resetPassword` functions in isolation. It also tests the initialization of the auth state.

- Updates `jest.config.js` to correctly handle module path aliases, allowing tests to run correctly.

- Adds a placeholder `firebase.config.js` file to resolve module loading issues in the Jest environment. This file is gitignored and is only present for testing purposes.